### PR TITLE
allow non-default rcon port

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In action:
 * Push this to Heroku
 * Point Slack outgoing webhooks to your Heroku URL
 * Set `SLACK_URL` as Slack incoming webhook URL
-* Make sure `RCON_IP`, `RCON_PASSWORD` are set in heroku configuration to your server's IP/hostname and RCON password
+* Make sure `RCON_IP`, `RCON_PASSWORD` are set in heroku configuration to your server's IP/hostname and RCON password. If `RCON_PORT` is not set it uses the default (25575).
 
 Run the following on your server hosting (in a screen, and make sure to replace your Heroku URL and your log directory location):
 

--- a/wither.rb
+++ b/wither.rb
@@ -1,6 +1,6 @@
 class Wither < Sinatra::Application
   def rcon(command)
-    rcon = RCON::Minecraft.new ENV['RCON_IP'], 25575
+    rcon = RCON::Minecraft.new ENV['RCON_IP'], ENV['RCON_PORT'] || 25575
     rcon.auth ENV['RCON_PASSWORD']
     rcon.command(command).strip
   end


### PR DESCRIPTION
Now you can set the `RCON_PORT` environment variable. Otherwise the default is used.

Note: although `ENV` doesn't return integers, we can use that because rcon just passes it to `TCPSocket.new` which works fine with strings because ruby :gem: 