### PR TITLE
remove quote replacement

### DIFF
--- a/wither.rb
+++ b/wither.rb
@@ -6,7 +6,7 @@ class Wither < Sinatra::Application
   end
 
   def say_in_game(user_name, text)
-    data = {text: "<#{user_name.gsub(/\Aslackbot\z/, "Steve")}> #{text.gsub("'", "’").gsub('"', "”")}"}
+    data = {text: "<#{user_name.gsub(/\Aslackbot\z/, "Steve")}> #{text}"}
     rcon %|tellraw @a ["",#{data.to_json}]|
   end
 


### PR DESCRIPTION
this isn't needed anymore because `to_json` escapes quotes properly